### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/anomaly-detection/values.yaml
+++ b/src/anomaly-detection/values.yaml
@@ -69,7 +69,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: "512m"
     memory: "512Mi"
   requests:
     cpu: "512m"

--- a/src/batch-processing/values.yaml
+++ b/src/batch-processing/values.yaml
@@ -173,7 +173,6 @@ workloadIdentity:
 
 resources:
   limits:
-    cpu: "1024m"
     memory: "10Gi"
   requests:
     cpu: "1024m"

--- a/src/ccm/values.yaml
+++ b/src/ccm/values.yaml
@@ -56,7 +56,6 @@ anomaly-detection:
   affinity: {}
   resources:
     limits:
-      cpu: "512m"
       memory: "512Mi"
     requests:
       cpu: "512m"
@@ -148,7 +147,6 @@ batch-processing:
     enabled: false
   resources:
     limits:
-      cpu: "1024m"
       memory: "10Gi"
     requests:
       cpu: "1024m"
@@ -199,7 +197,6 @@ cloud-info:
     enabled: false
   resources:
     limits:
-      cpu: "1536m"
       memory: "1536Mi"
     requests:
       cpu: "1536m"
@@ -267,7 +264,6 @@ event-service:
     className: nginx
   resources:
     limits:
-      cpu: "512m"
       memory: "1840Mi"
     requests:
       cpu: "512m"
@@ -348,7 +344,6 @@ lwd:
   affinity: {}
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -420,7 +415,6 @@ lwd-autocud:
   affinity: {}
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -472,7 +466,6 @@ lwd-faktory:
     accessModes: "ReadWriteOnce"
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -544,7 +537,6 @@ lwd-worker:
   affinity: {}
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -636,7 +628,6 @@ nextgen-ce:
     enabled: false
   resources:
     limits:
-      cpu: 1
       memory: "4Gi"
     requests:
       cpu: 1
@@ -679,7 +670,6 @@ ng-ce-ui:
   affinity: {}
   resources:
     limits:
-      cpu: 1
       memory: "512Mi"
     requests:
       cpu: 1
@@ -729,7 +719,6 @@ telescopes:
   affinity: {}
   resources:
     limits:
-      cpu: "512m"
       memory: "1Gi"
     requests:
       cpu: "512m"
@@ -742,7 +731,6 @@ clickhouse:
     tag: 22.11.2-debian-11-r0
   resources:
     limits:
-      cpu: 6
       memory: "8Gi"
     requests:
       cpu: 6

--- a/src/cloud-info/values.yaml
+++ b/src/cloud-info/values.yaml
@@ -85,7 +85,6 @@ workloadIdentity:
 
 resources:
   limits:
-    cpu: "1536m"
     memory: "1536Mi"
   requests:
     cpu: "1536m"

--- a/src/event-service/values.yaml
+++ b/src/event-service/values.yaml
@@ -141,7 +141,6 @@ ingress:
 
 resources:
   limits:
-    cpu: "512m"
     memory: "1840Mi"
   requests:
     cpu: "512m"

--- a/src/lightwingAPI/values.yaml
+++ b/src/lightwingAPI/values.yaml
@@ -113,7 +113,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/lightwingAutocud/values.yaml
+++ b/src/lightwingAutocud/values.yaml
@@ -114,7 +114,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/lightwingFaktory/values.yaml
+++ b/src/lightwingFaktory/values.yaml
@@ -82,7 +82,6 @@ persistentVolume:
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/lightwingFaktoryWorker/values.yaml
+++ b/src/lightwingFaktoryWorker/values.yaml
@@ -108,7 +108,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/nextgen-ce/values.yaml
+++ b/src/nextgen-ce/values.yaml
@@ -177,7 +177,6 @@ workloadIdentity:
 
 resources:
   limits:
-    cpu: 1
     memory: "4Gi"
   requests:
     cpu: 1

--- a/src/ng-ce-ui/values.yaml
+++ b/src/ng-ce-ui/values.yaml
@@ -73,7 +73,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 1
     memory: "512Mi"
   requests:
     cpu: 1

--- a/src/telescopes/values.yaml
+++ b/src/telescopes/values.yaml
@@ -83,7 +83,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: "512m"
     memory: "1Gi"
   requests:
     cpu: "512m"


### PR DESCRIPTION
As per best practices, utilizing requests.cpu and removing limits.cpu

Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)