### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/anomaly-detection/values.yaml
+++ b/src/anomaly-detection/values.yaml
@@ -70,7 +70,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: "512m"
     memory: "512Mi"
   requests:
     cpu: "512m"

--- a/src/batch-processing/values.yaml
+++ b/src/batch-processing/values.yaml
@@ -173,7 +173,6 @@ workloadIdentity:
 
 resources:
   limits:
-    cpu: "1024m"
     memory: "10Gi"
   requests:
     cpu: "1024m"

--- a/src/ccm/values.yaml
+++ b/src/ccm/values.yaml
@@ -68,7 +68,6 @@ anomaly-detection:
   affinity: {}
   resources:
     limits:
-      cpu: "512m"
       memory: "512Mi"
     requests:
       cpu: "512m"
@@ -160,7 +159,6 @@ batch-processing:
     enabled: false
   resources:
     limits:
-      cpu: "1024m"
       memory: "10Gi"
     requests:
       cpu: "1024m"
@@ -211,7 +209,6 @@ cloud-info:
     enabled: false
   resources:
     limits:
-      cpu: "1536m"
       memory: "1536Mi"
     requests:
       cpu: "1536m"
@@ -279,7 +276,6 @@ event-service:
     className: nginx
   resources:
     limits:
-      cpu: "512m"
       memory: "1840Mi"
     requests:
       cpu: "512m"
@@ -360,7 +356,6 @@ lwd:
   affinity: {}
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -432,7 +427,6 @@ lwd-autocud:
   affinity: {}
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -485,7 +479,6 @@ lwd-faktory:
     accessModes: "ReadWriteOnce"
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -557,7 +550,6 @@ lwd-worker:
   affinity: {}
   resources:
     limits:
-      cpu: 2
       memory: "4Gi"
     requests:
       cpu: 2
@@ -649,7 +641,6 @@ nextgen-ce:
     enabled: false
   resources:
     limits:
-      cpu: 1
       memory: "4Gi"
     requests:
       cpu: 1
@@ -693,7 +684,6 @@ ng-ce-ui:
   affinity: {}
   resources:
     limits:
-      cpu: 1
       memory: "512Mi"
     requests:
       cpu: 1
@@ -743,7 +733,6 @@ telescopes:
   affinity: {}
   resources:
     limits:
-      cpu: "512m"
       memory: "1Gi"
     requests:
       cpu: "512m"
@@ -756,7 +745,6 @@ clickhouse:
     tag: 22.11.2-debian-11-r0
   resources:
     limits:
-      cpu: 6
       memory: "8Gi"
     requests:
       cpu: 6

--- a/src/cloud-info/values.yaml
+++ b/src/cloud-info/values.yaml
@@ -85,7 +85,6 @@ workloadIdentity:
 
 resources:
   limits:
-    cpu: "1536m"
     memory: "1536Mi"
   requests:
     cpu: "1536m"

--- a/src/dkron/values.yaml
+++ b/src/dkron/values.yaml
@@ -71,7 +71,6 @@ persistentVolume:
 
 resources:
   limits:
-    cpu: 1
     memory: "2Gi"
   requests:
     cpu: 1

--- a/src/event-service/values.yaml
+++ b/src/event-service/values.yaml
@@ -141,7 +141,6 @@ ingress:
 
 resources:
   limits:
-    cpu: "512m"
     memory: "1840Mi"
   requests:
     cpu: "512m"

--- a/src/lightwingAPI/values.yaml
+++ b/src/lightwingAPI/values.yaml
@@ -123,7 +123,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/lightwingAutocud/values.yaml
+++ b/src/lightwingAutocud/values.yaml
@@ -114,7 +114,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/lightwingFaktory/values.yaml
+++ b/src/lightwingFaktory/values.yaml
@@ -83,7 +83,6 @@ persistentVolume:
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/lightwingFaktoryWorker/values.yaml
+++ b/src/lightwingFaktoryWorker/values.yaml
@@ -118,7 +118,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 2
     memory: "4Gi"
   requests:
     cpu: 2

--- a/src/nextgen-ce/values.yaml
+++ b/src/nextgen-ce/values.yaml
@@ -177,7 +177,6 @@ workloadIdentity:
 
 resources:
   limits:
-    cpu: 1
     memory: "4Gi"
   requests:
     cpu: 1

--- a/src/ng-ce-ui/values.yaml
+++ b/src/ng-ce-ui/values.yaml
@@ -74,7 +74,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: 1
     memory: "512Mi"
   requests:
     cpu: 1

--- a/src/telescopes/values.yaml
+++ b/src/telescopes/values.yaml
@@ -83,7 +83,6 @@ affinity: {}
 
 resources:
   limits:
-    cpu: "512m"
     memory: "1Gi"
   requests:
     cpu: "512m"


### PR DESCRIPTION
Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)