### PR TITLE
[SMP-1468]: Add lifecyclehooks, volume, volumemounts to release/0.8.0

### DIFF
--- a/src/anomaly-detection/templates/deployment.yaml
+++ b/src/anomaly-detection/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             initialDelaySeconds: 300
             timeoutSeconds: 5
             periodSeconds: 40
-            failureThreshold: 
+            failureThreshold: 20
         {{- if .Values.lifecycleHooks }}
           lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
         {{- end }}

--- a/src/anomaly-detection/templates/deployment.yaml
+++ b/src/anomaly-detection/templates/deployment.yaml
@@ -51,7 +51,14 @@ spec:
             initialDelaySeconds: 300
             timeoutSeconds: 5
             periodSeconds: 40
-            failureThreshold: 20
+            failureThreshold: 
+        {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+        {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -73,4 +80,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/anomaly-detection/values.yaml
+++ b/src/anomaly-detection/values.yaml
@@ -75,3 +75,24 @@ resources:
   requests:
     cpu: "512m"
     memory: "512Mi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/cloud-info/templates/deployment.yaml
+++ b/src/cloud-info/templates/deployment.yaml
@@ -55,6 +55,13 @@ spec:
           volumeMounts:
           - name: secret-mount
             mountPath: /config
+        {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+        {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
       volumes:
       - name: secret-mount
         secret:
@@ -87,4 +94,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/cloud-info/values.yaml
+++ b/src/cloud-info/values.yaml
@@ -90,3 +90,24 @@ resources:
   requests:
     cpu: "1536m"
     memory: "1536Mi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/event-service/templates/deployment.yaml
+++ b/src/event-service/templates/deployment.yaml
@@ -85,6 +85,13 @@ spec:
               value: postgres
             - name: TIMESCALEDB_URI
               value: 'jdbc:postgresql://timescaledb-single-chart.{{ .Release.Namespace }}:5432/harness'
+        {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+        {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -106,4 +113,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/event-service/values.yaml
+++ b/src/event-service/values.yaml
@@ -161,3 +161,24 @@ tolerations: []
 affinity: {}
 
 additionalConfigs: {}
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingAPI/templates/deployment.yaml
+++ b/src/lightwingAPI/templates/deployment.yaml
@@ -122,9 +122,15 @@ spec:
               value: tcp://:$(FAKTORY_PASSWORD)@lwd-faktory.{{ .Release.Namespace }}.svc.cluster.local:7419
             - name: LIGHTWING_DKRON_HOST
               value: http://dkron.{{ .Release.Namespace }}.svc.cluster.local:8080
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: secret-mount
             mountPath: /opt/harness/svc
+        {{- if .Values.extraVolumeMounts }}
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
       volumes:
       - name: secret-mount
         secret:
@@ -132,6 +138,9 @@ spec:
           items:
           - key: ce-batch-gcp-credentials
             path: ce_batch_gcp_credentials.json
+      {{- if .Values.extraVolumes }}
+        {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/src/lightwingAPI/values.yaml
+++ b/src/lightwingAPI/values.yaml
@@ -128,3 +128,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingAutocud/templates/deployment.yaml
+++ b/src/lightwingAutocud/templates/deployment.yaml
@@ -136,10 +136,19 @@ spec:
                   key: {{ .Values.lwdAutocudSecrets.faktoryPassword }}
             - name: FAKTORY_URL
               value: tcp://$(FAKTORY_PASSWORD):@lwd-faktory.{{ .Release.Namespace }}.svc.cluster.local:7419
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: secret-mount
             mountPath: /opt/harness/svc
+        {{- if .Values.extraVolumeMounts }}
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
       volumes:
+      {{- if .Values.extraVolumes }}
+        {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: lwd-autocud-secret-mount

--- a/src/lightwingAutocud/values.yaml
+++ b/src/lightwingAutocud/values.yaml
@@ -119,3 +119,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingFaktory/templates/deployment.yaml
+++ b/src/lightwingFaktory/templates/deployment.yaml
@@ -57,11 +57,20 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.faktory.password.name }}
                   key: {{ .Values.faktory.password.key }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+        {{- if .Values.extraVolumeMounts }}
+        {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
           - name: lwd-faktory-mount
             mountPath: /var/lib/faktory
       restartPolicy: Always
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: lwd-faktory-mount
         persistentVolumeClaim:
           claimName: lwd-faktory

--- a/src/lightwingFaktory/values.yaml
+++ b/src/lightwingFaktory/values.yaml
@@ -88,3 +88,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingFaktoryWorker/templates/deployment.yaml
+++ b/src/lightwingFaktoryWorker/templates/deployment.yaml
@@ -136,10 +136,19 @@ spec:
                   key: {{ .Values.lwdWorkerSecrets.faktoryPassword }}
             - name: FAKTORY_URL
               value: tcp://:$(FAKTORY_PASSWORD)@lwd-faktory.{{ .Release.Namespace }}.svc.cluster.local:7419
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+        {{- if .Values.extraVolumeMounts }}
+        {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
           - name: secret-mount
             mountPath: /opt/harness/svc
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: lwd-worker-secret-mount

--- a/src/lightwingFaktoryWorker/values.yaml
+++ b/src/lightwingFaktoryWorker/values.yaml
@@ -123,3 +123,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/nextgen-ce/templates/deployment.yaml
+++ b/src/nextgen-ce/templates/deployment.yaml
@@ -102,12 +102,21 @@ spec:
                   key: {{ .Values.clickhouse.password.key }}
             {{- end }}
           {{- if not .Values.workloadIdentity.enabled }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+        {{- if .Values.extraVolumeMounts }}
+        {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
           - name: secret-mount
             mountPath: /opt/harness/svc
           {{- end }}
       {{- if not .Values.workloadIdentity.enabled }}
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: ceng-secret-mount

--- a/src/nextgen-ce/values.yaml
+++ b/src/nextgen-ce/values.yaml
@@ -184,3 +184,24 @@ resources:
     memory: "4Gi"
 
 additionalConfigs: {}
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/ng-ce-ui/templates/deployment.yaml
+++ b/src/ng-ce-ui/templates/deployment.yaml
@@ -55,6 +55,13 @@ spec:
           - name: ng-ce-ui-port
             containerPort: 8080
             protocol: "TCP"
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -76,4 +83,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/ng-ce-ui/values.yaml
+++ b/src/ng-ce-ui/values.yaml
@@ -79,3 +79,24 @@ resources:
   requests:
     cpu: 1
     memory: "512Mi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/telescopes/templates/deployment.yaml
+++ b/src/telescopes/templates/deployment.yaml
@@ -44,6 +44,13 @@ spec:
           - |
             /bin/telescopes \
             --cloudinfo-address="http://cloud-info.{{ .Release.Namespace }}.svc.cluster.local:8082/api/v1"
+        {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+        {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -65,4 +72,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/telescopes/values.yaml
+++ b/src/telescopes/values.yaml
@@ -88,3 +88,24 @@ resources:
   requests:
     cpu: "512m"
     memory: "1Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:


### PR DESCRIPTION
Currently override file does not allow for following :

lifecycle.postStart, lifecycle.preStop, volume and volume mount - need for JFR integration

This would be helpful as part of performance testing to add additional volumes and volumeMounts for certain files like jfr recording etc, preStop, postStart lifecycle hooks.

This functionality will help in future if we need to mount certificates on the container if required(mongo/postgres certificates) or analysing the cause of crashes.

These are created with checking best practices like bitnami charts in mind. It is currently harmless in nature, and can be invoked by setting the configurations in overrides/values.yaml