### PR TITLE
[SMP-1468]: Add volumemounts, volumes, lifecyclehooks to release/0.8.0

### DIFF
--- a/src/anomaly-detection/README.md
+++ b/src/anomaly-detection/README.md
@@ -20,6 +20,8 @@ A Helm chart for Kubernetes
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPU | string | `""` |  |
 | autoscaling.targetMemory | string | `""` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.imagePullSecrets | list | `[]` |  |
 | global.ingress.className | string | `"harness"` |  |
@@ -37,6 +39,7 @@ A Helm chart for Kubernetes
 | ingress.className | string | `"nginx"` |  |
 | java.memory | string | `"4096m"` |  |
 | java.memoryLimit | string | `"4096m"` |  |
+| lifecycleHooks | object | `{}` |  |
 | maxSurge | string | `"100%"` |  |
 | maxUnavailable | int | `0` |  |
 | nameOverride | string | `""` |  |
@@ -44,7 +47,6 @@ A Helm chart for Kubernetes
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"512m"` |  |
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | string | `"512m"` |  |
 | resources.requests.memory | string | `"512Mi"` |  |

--- a/src/anomaly-detection/templates/deployment.yaml
+++ b/src/anomaly-detection/templates/deployment.yaml
@@ -52,6 +52,18 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 40
             failureThreshold: 20
+<<<<<<< HEAD
+=======
+        {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+        {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -73,4 +85,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/anomaly-detection/values.yaml
+++ b/src/anomaly-detection/values.yaml
@@ -75,3 +75,24 @@ resources:
   requests:
     cpu: "512m"
     memory: "512Mi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/batch-processing/README.md
+++ b/src/batch-processing/README.md
@@ -36,6 +36,8 @@ A Helm chart for Kubernetes
 | cloudProviderConfig.DATA_PIPELINE_CONFIG_GCS_BASE_PATH | string | `"gs://awscustomerbillingdata-onprem"` |  |
 | cloudProviderConfig.S3_SYNC_CONFIG_BUCKET_NAME | string | `"ccm-service-data-bucket"` |  |
 | cloudProviderConfig.S3_SYNC_CONFIG_REGION | string | `"us-east-1"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.ccm.gcpProjectId | string | `"placeHolder"` |  |
 | global.database.mongo.extraArgs | string | `""` |  |
@@ -82,6 +84,7 @@ A Helm chart for Kubernetes
 | imageClickhouseEnabled.tag | string | `"79404-000"` |  |
 | isolatedReplica | int | `0` |  |
 | java.memory | string | `"7168"` |  |
+| lifecycleHooks | object | `{}` |  |
 | mongoSecrets.password.key | string | `"mongodb-root-password"` |  |
 | mongoSecrets.password.name | string | `"mongodb-replicaset-chart"` |  |
 | mongoSecrets.userName.key | string | `"mongodbUsername"` |  |
@@ -91,7 +94,6 @@ A Helm chart for Kubernetes
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"1024m"` |  |
 | resources.limits.memory | string | `"10Gi"` |  |
 | resources.requests.cpu | string | `"1024m"` |  |
 | resources.requests.memory | string | `"10Gi"` |  |

--- a/src/batch-processing/templates/statefulset.yaml
+++ b/src/batch-processing/templates/statefulset.yaml
@@ -91,10 +91,19 @@ spec:
                   name: {{ .Values.clickhouse.password.name }}
                   key: {{ .Values.clickhouse.password.key }}
             {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+          {{- end }}
           - name: secret-mount
             mountPath: /opt/harness/svc
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: batch-processing-secret-mount

--- a/src/batch-processing/values.yaml
+++ b/src/batch-processing/values.yaml
@@ -180,3 +180,24 @@ resources:
     memory: "10Gi"
 
 additionalConfigs: {}
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/ccm/Chart.yaml
+++ b/src/ccm/Chart.yaml
@@ -13,7 +13,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
+<<<<<<< HEAD
 version: 0.7.2
+=======
+version: 0.7.4
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/src/ccm/README.md
+++ b/src/ccm/README.md
@@ -2,7 +2,11 @@
 
 A Helm chart for Harness Cloud Cost Management (CCM) module
 
+<<<<<<< HEAD
 ![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.546.0](https://img.shields.io/badge/AppVersion-1.546.0-informational?style=flat-square)
+=======
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.546.0](https://img.shields.io/badge/AppVersion-1.546.0-informational?style=flat-square)
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
 
 ## Usage
 
@@ -12,7 +16,11 @@ Use the following dependency to add this chart repository to your Helm installat
 dependencies:
     - name: ccm
       repository: https://harness.github.io/helm-ccm
+<<<<<<< HEAD
       version: 0.7.2
+=======
+      version: 0.7.4
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
 ```
 
 ## Values
@@ -41,7 +49,6 @@ dependencies:
 | anomaly-detection.podAnnotations | object | `{}` |  |
 | anomaly-detection.podSecurityContext | object | `{}` |  |
 | anomaly-detection.replicaCount | int | `1` |  |
-| anomaly-detection.resources.limits.cpu | string | `"512m"` |  |
 | anomaly-detection.resources.limits.memory | string | `"512Mi"` |  |
 | anomaly-detection.resources.requests.cpu | string | `"512m"` |  |
 | anomaly-detection.resources.requests.memory | string | `"512Mi"` |  |
@@ -95,7 +102,6 @@ dependencies:
 | batch-processing.podAnnotations | object | `{}` |  |
 | batch-processing.podSecurityContext | object | `{}` |  |
 | batch-processing.replicaCount | int | `1` |  |
-| batch-processing.resources.limits.cpu | string | `"1024m"` |  |
 | batch-processing.resources.limits.memory | string | `"10Gi"` |  |
 | batch-processing.resources.requests.cpu | string | `"1024m"` |  |
 | batch-processing.resources.requests.memory | string | `"10Gi"` |  |
@@ -124,7 +130,6 @@ dependencies:
 | clickhouse.image.tag | string | `"22.11.2-debian-11-r0"` |  |
 | clickhouse.persistence.size | string | `"1Ti"` |  |
 | clickhouse.replicaCount | int | `1` |  |
-| clickhouse.resources.limits.cpu | int | `6` |  |
 | clickhouse.resources.limits.memory | string | `"8Gi"` |  |
 | clickhouse.resources.requests.cpu | int | `6` |  |
 | clickhouse.resources.requests.memory | string | `"8Gi"` |  |
@@ -156,7 +161,6 @@ dependencies:
 | cloud-info.podAnnotations | object | `{}` |  |
 | cloud-info.podSecurityContext | object | `{}` |  |
 | cloud-info.replicaCount | int | `1` |  |
-| cloud-info.resources.limits.cpu | string | `"1536m"` |  |
 | cloud-info.resources.limits.memory | string | `"1536Mi"` |  |
 | cloud-info.resources.requests.cpu | string | `"1536m"` |  |
 | cloud-info.resources.requests.memory | string | `"1536Mi"` |  |
@@ -198,7 +202,6 @@ dependencies:
 | event-service.podSecurityContext | object | `{}` |  |
 | event-service.redislabsCATruststore | string | `"test"` |  |
 | event-service.replicaCount | int | `1` |  |
-| event-service.resources.limits.cpu | string | `"512m"` |  |
 | event-service.resources.limits.memory | string | `"1840Mi"` |  |
 | event-service.resources.requests.cpu | string | `"512m"` |  |
 | event-service.resources.requests.memory | string | `"1840Mi"` |  |
@@ -272,7 +275,6 @@ dependencies:
 | lwd-autocud.redis.redisUrl | string | `"redis://localhost:6379"` |  |
 | lwd-autocud.redis.useSentinel | string | `"true"` |  |
 | lwd-autocud.replicaCount | int | `2` |  |
-| lwd-autocud.resources.limits.cpu | int | `2` |  |
 | lwd-autocud.resources.limits.memory | string | `"4Gi"` |  |
 | lwd-autocud.resources.requests.cpu | int | `2` |  |
 | lwd-autocud.resources.requests.memory | string | `"4Gi"` |  |
@@ -310,7 +312,6 @@ dependencies:
 | lwd-faktory.podAnnotations | object | `{}` |  |
 | lwd-faktory.podSecurityContext | object | `{}` |  |
 | lwd-faktory.replicaCount | int | `1` |  |
-| lwd-faktory.resources.limits.cpu | int | `2` |  |
 | lwd-faktory.resources.limits.memory | string | `"4Gi"` |  |
 | lwd-faktory.resources.requests.cpu | int | `2` |  |
 | lwd-faktory.resources.requests.memory | string | `"4Gi"` |  |
@@ -362,7 +363,6 @@ dependencies:
 | lwd-worker.redis.redisUrl | string | `"redis://localhost:6379"` |  |
 | lwd-worker.redis.useSentinel | string | `"true"` |  |
 | lwd-worker.replicaCount | int | `3` |  |
-| lwd-worker.resources.limits.cpu | int | `2` |  |
 | lwd-worker.resources.limits.memory | string | `"4Gi"` |  |
 | lwd-worker.resources.requests.cpu | int | `2` |  |
 | lwd-worker.resources.requests.memory | string | `"4Gi"` |  |
@@ -415,7 +415,6 @@ dependencies:
 | lwd.redis.redisUrl | string | `"redis://localhost:6379"` |  |
 | lwd.redis.useSentinel | string | `"true"` |  |
 | lwd.replicaCount | int | `2` |  |
-| lwd.resources.limits.cpu | int | `2` |  |
 | lwd.resources.limits.memory | string | `"4Gi"` |  |
 | lwd.resources.requests.cpu | int | `2` |  |
 | lwd.resources.requests.memory | string | `"4Gi"` |  |
@@ -479,7 +478,6 @@ dependencies:
 | nextgen-ce.podAnnotations | object | `{}` |  |
 | nextgen-ce.podSecurityContext | object | `{}` |  |
 | nextgen-ce.replicaCount | int | `2` |  |
-| nextgen-ce.resources.limits.cpu | int | `1` |  |
 | nextgen-ce.resources.limits.memory | string | `"4Gi"` |  |
 | nextgen-ce.resources.requests.cpu | int | `1` |  |
 | nextgen-ce.resources.requests.memory | string | `"4Gi"` |  |
@@ -518,7 +516,6 @@ dependencies:
 | ng-ce-ui.podAnnotations | object | `{}` |  |
 | ng-ce-ui.podSecurityContext | object | `{}` |  |
 | ng-ce-ui.replicaCount | int | `2` |  |
-| ng-ce-ui.resources.limits.cpu | int | `1` |  |
 | ng-ce-ui.resources.limits.memory | string | `"512Mi"` |  |
 | ng-ce-ui.resources.requests.cpu | int | `1` |  |
 | ng-ce-ui.resources.requests.memory | string | `"512Mi"` |  |
@@ -550,7 +547,6 @@ dependencies:
 | telescopes.podAnnotations | object | `{}` |  |
 | telescopes.podSecurityContext | object | `{}` |  |
 | telescopes.replicaCount | int | `1` |  |
-| telescopes.resources.limits.cpu | string | `"512m"` |  |
 | telescopes.resources.limits.memory | string | `"1Gi"` |  |
 | telescopes.resources.requests.cpu | string | `"512m"` |  |
 | telescopes.resources.requests.memory | string | `"1Gi"` |  |

--- a/src/cloud-info/README.md
+++ b/src/cloud-info/README.md
@@ -22,6 +22,8 @@ A Helm chart for Kubernetes
 | autoscaling.maxReplicas | int | `2` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.imagePullSecrets | list | `[]` |  |
 | global.ingress.className | string | `"harness"` |  |
@@ -43,6 +45,7 @@ A Helm chart for Kubernetes
 | ingress.className | string | `"nginx"` |  |
 | java.memory | string | `"4096m"` |  |
 | java.memoryLimit | string | `"4096m"` |  |
+| lifecycleHooks | object | `{}` |  |
 | maxSurge | string | `"100%"` |  |
 | maxUnavailable | int | `0` |  |
 | nameOverride | string | `""` |  |
@@ -50,7 +53,6 @@ A Helm chart for Kubernetes
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"1536m"` |  |
 | resources.limits.memory | string | `"1536Mi"` |  |
 | resources.requests.cpu | string | `"1536m"` |  |
 | resources.requests.memory | string | `"1536Mi"` |  |

--- a/src/cloud-info/templates/deployment.yaml
+++ b/src/cloud-info/templates/deployment.yaml
@@ -52,10 +52,20 @@ spec:
           env:
           - name: USE_WORKLOAD_IDENTITY
             value: {{ .Values.workloadIdentity.enabled | quote }}
+
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+          {{- end }}
           - name: secret-mount
             mountPath: /config
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: cloud-info-secret-mount

--- a/src/cloud-info/values.yaml
+++ b/src/cloud-info/values.yaml
@@ -90,3 +90,24 @@ resources:
   requests:
     cpu: "1536m"
     memory: "1536Mi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/dkron/README.md
+++ b/src/dkron/README.md
@@ -20,6 +20,8 @@ A Helm chart for Kubernetes
 | autoscaling.maxReplicas | int | `2` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.imagePullSecrets | list | `[]` |  |
 | global.ingress.className | string | `"harness"` |  |
@@ -39,6 +41,7 @@ A Helm chart for Kubernetes
 | image.repository | string | `"harness/dkron-ubi-signed"` |  |
 | image.tag | string | `"1002"` |  |
 | ingress.className | string | `"nginx"` |  |
+| lifecycleHooks | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistentVolume.accessModes | string | `"ReadWriteOnce"` |  |
@@ -46,7 +49,6 @@ A Helm chart for Kubernetes
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | int | `1` |  |
 | resources.limits.memory | string | `"2Gi"` |  |
 | resources.requests.cpu | int | `1` |  |
 | resources.requests.memory | string | `"2Gi"` |  |

--- a/src/dkron/templates/statefulset.yaml
+++ b/src/dkron/templates/statefulset.yaml
@@ -45,7 +45,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+          {{- end }}
           - name: dkrondata
             mountPath: /dkron/dkrondata
           - name: config
@@ -70,6 +76,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
+        {{- if .Values.extraVolumes }}
+        {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
         - name: config
           configMap:
             name: dkron-server

--- a/src/dkron/values.yaml
+++ b/src/dkron/values.yaml
@@ -76,3 +76,24 @@ resources:
   requests:
     cpu: 1
     memory: "2Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/event-service/README.md
+++ b/src/event-service/README.md
@@ -23,6 +23,8 @@ A Helm chart for Kubernetes
 | autoscaling.targetCPU | string | `""` |  |
 | autoscaling.targetMemory | string | `""` |  |
 | defaultInternalImageConnector | string | `"test"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.database.mongo.extraArgs | string | `""` |  |
 | global.database.mongo.hosts | list | `[]` | provide default values if mongo.installed is set to false |
@@ -65,6 +67,7 @@ A Helm chart for Kubernetes
 | image.tag | string | `"79404-000"` |  |
 | ingress.className | string | `"nginx"` |  |
 | java.memory | int | `1024` |  |
+| lifecycleHooks | object | `{}` |  |
 | maxSurge | string | `"100%"` |  |
 | maxUnavailable | int | `0` |  |
 | mongoSecrets.password.key | string | `"mongodb-root-password"` |  |
@@ -78,7 +81,6 @@ A Helm chart for Kubernetes
 | podSecurityContext | object | `{}` |  |
 | redislabsCATruststore | string | `"test"` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"512m"` |  |
 | resources.limits.memory | string | `"1840Mi"` |  |
 | resources.requests.cpu | string | `"512m"` |  |
 | resources.requests.memory | string | `"1840Mi"` |  |

--- a/src/event-service/templates/deployment.yaml
+++ b/src/event-service/templates/deployment.yaml
@@ -85,6 +85,18 @@ spec:
               value: postgres
             - name: TIMESCALEDB_URI
               value: 'jdbc:postgresql://timescaledb-single-chart.{{ .Release.Namespace }}:5432/harness'
+<<<<<<< HEAD
+=======
+        {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+        {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -106,4 +118,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/event-service/values.yaml
+++ b/src/event-service/values.yaml
@@ -161,3 +161,24 @@ tolerations: []
 affinity: {}
 
 additionalConfigs: {}
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingAPI/README.md
+++ b/src/lightwingAPI/README.md
@@ -31,6 +31,8 @@ A Helm chart for Kubernetes
 | clickhouse.password.name | string | `"clickhouse"` |  |
 | clickhouse.port | int | `9000` |  |
 | clickhouse.username | string | `"default"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.ccm.gcpProjectId | string | `"placeHolder"` |  |
 | global.imagePullSecrets | list | `[]` |  |
@@ -53,6 +55,7 @@ A Helm chart for Kubernetes
 | ingress.className | string | `"nginx"` |  |
 | java.memory | string | `"4096m"` |  |
 | java.memoryLimit | string | `"4096m"` |  |
+| lifecycleHooks | object | `{}` |  |
 | lwdSecrets.faktoryPassword | string | `""` |  |
 | lwdSecrets.lightwingAwsGovmasterAccessKey | string | `""` |  |
 | lwdSecrets.lightwingAwsGovmasterSecretKey | string | `""` |  |
@@ -72,7 +75,6 @@ A Helm chart for Kubernetes
 | redis.redisUrl | string | `"redis://localhost:6379"` |  |
 | redis.useSentinel | string | `"true"` |  |
 | replicaCount | int | `2` |  |
-| resources.limits.cpu | int | `2` |  |
 | resources.limits.memory | string | `"4Gi"` |  |
 | resources.requests.cpu | int | `2` |  |
 | resources.requests.memory | string | `"4Gi"` |  |

--- a/src/lightwingAPI/templates/deployment.yaml
+++ b/src/lightwingAPI/templates/deployment.yaml
@@ -122,9 +122,20 @@ spec:
               value: tcp://:$(FAKTORY_PASSWORD)@lwd-faktory.{{ .Release.Namespace }}.svc.cluster.local:7419
             - name: LIGHTWING_DKRON_HOST
               value: http://dkron.{{ .Release.Namespace }}.svc.cluster.local:8080
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: secret-mount
             mountPath: /opt/harness/svc
+<<<<<<< HEAD
+=======
+        {{- if .Values.extraVolumeMounts }}
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
       volumes:
       - name: secret-mount
         secret:
@@ -132,6 +143,9 @@ spec:
           items:
           - key: ce-batch-gcp-credentials
             path: ce_batch_gcp_credentials.json
+      {{- if .Values.extraVolumes }}
+        {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/src/lightwingAPI/values.yaml
+++ b/src/lightwingAPI/values.yaml
@@ -128,3 +128,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingAutocud/README.md
+++ b/src/lightwingAutocud/README.md
@@ -24,6 +24,8 @@ A Helm chart for Kubernetes
 | aws.region | string | `"us-east-1"` |  |
 | azure.clientId | string | `""` |  |
 | ce-batch-gcp-credentials | string | `""` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.ccm.gcpProjectId | string | `"placeHolder"` |  |
 | global.imagePullSecrets | list | `[]` |  |
@@ -46,6 +48,7 @@ A Helm chart for Kubernetes
 | ingress.className | string | `"nginx"` |  |
 | java.memory | string | `"4096m"` |  |
 | java.memoryLimit | string | `"4096m"` |  |
+| lifecycleHooks | object | `{}` |  |
 | lwdAutocudSecrets.faktoryPassword | string | `"FAKTORY_PASSWORD"` |  |
 | lwdAutocudSecrets.lightwingAwsGovmasterAccessKey | string | `"LIGHTWING_AWS-GOV-MASTER_ACCESS_KEY"` |  |
 | lwdAutocudSecrets.lightwingAwsGovmasterSecretKey | string | `"LIGHTWING_AWS-GOV-MASTER_SECRET_KEY"` |  |
@@ -66,7 +69,6 @@ A Helm chart for Kubernetes
 | redis.redisUrl | string | `"redis://localhost:6379"` |  |
 | redis.useSentinel | string | `"true"` |  |
 | replicaCount | int | `2` |  |
-| resources.limits.cpu | int | `2` |  |
 | resources.limits.memory | string | `"4Gi"` |  |
 | resources.requests.cpu | int | `2` |  |
 | resources.requests.memory | string | `"4Gi"` |  |

--- a/src/lightwingAutocud/templates/deployment.yaml
+++ b/src/lightwingAutocud/templates/deployment.yaml
@@ -136,10 +136,24 @@ spec:
                   key: {{ .Values.lwdAutocudSecrets.faktoryPassword }}
             - name: FAKTORY_URL
               value: tcp://$(FAKTORY_PASSWORD):@lwd-faktory.{{ .Release.Namespace }}.svc.cluster.local:7419
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: secret-mount
             mountPath: /opt/harness/svc
+<<<<<<< HEAD
+=======
+        {{- if .Values.extraVolumeMounts }}
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
       volumes:
+      {{- if .Values.extraVolumes }}
+        {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: lwd-autocud-secret-mount

--- a/src/lightwingAutocud/values.yaml
+++ b/src/lightwingAutocud/values.yaml
@@ -119,3 +119,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingFaktory/README.md
+++ b/src/lightwingFaktory/README.md
@@ -20,6 +20,8 @@ A Helm chart for Kubernetes
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPU | string | `""` |  |
 | autoscaling.targetMemory | string | `""` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | faktory.password.key | string | `"FAKTORY_PASSWORD"` |  |
 | faktory.password.name | string | `"lwd-secrets"` |  |
 | fullnameOverride | string | `""` |  |
@@ -41,6 +43,7 @@ A Helm chart for Kubernetes
 | image.repository | string | `"contribsys/faktory"` |  |
 | image.tag | string | `"1.6.1"` |  |
 | ingress.className | string | `"nginx"` |  |
+| lifecycleHooks | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistentVolume.accessModes | string | `"ReadWriteOnce"` |  |
@@ -48,7 +51,6 @@ A Helm chart for Kubernetes
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | int | `2` |  |
 | resources.limits.memory | string | `"4Gi"` |  |
 | resources.requests.cpu | int | `2` |  |
 | resources.requests.memory | string | `"4Gi"` |  |

--- a/src/lightwingFaktory/templates/deployment.yaml
+++ b/src/lightwingFaktory/templates/deployment.yaml
@@ -57,11 +57,20 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.faktory.password.name }}
                   key: {{ .Values.faktory.password.key }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+        {{- if .Values.extraVolumeMounts }}
+        {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
           - name: lwd-faktory-mount
             mountPath: /var/lib/faktory
       restartPolicy: Always
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: lwd-faktory-mount
         persistentVolumeClaim:
           claimName: lwd-faktory

--- a/src/lightwingFaktory/values.yaml
+++ b/src/lightwingFaktory/values.yaml
@@ -88,3 +88,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/lightwingFaktoryWorker/README.md
+++ b/src/lightwingFaktoryWorker/README.md
@@ -31,6 +31,8 @@ A Helm chart for Kubernetes
 | clickhouse.password.name | string | `"clickhouse"` |  |
 | clickhouse.port | int | `9000` |  |
 | clickhouse.username | string | `"default"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.ccm.gcpProjectId | string | `"placeHolder"` |  |
 | global.imagePullSecrets | list | `[]` |  |
@@ -49,6 +51,7 @@ A Helm chart for Kubernetes
 | ingress.className | string | `"nginx"` |  |
 | java.memory | string | `"4096m"` |  |
 | java.memoryLimit | string | `"4096m"` |  |
+| lifecycleHooks | object | `{}` |  |
 | lwdWorkerSecrets.faktoryPassword | string | `"FAKTORY_PASSWORD"` |  |
 | lwdWorkerSecrets.lightwingAwsGovmasterAccessKey | string | `"LIGHTWING_AWS-GOV-MASTER_ACCESS_KEY"` |  |
 | lwdWorkerSecrets.lightwingAwsGovmasterSecretKey | string | `"LIGHTWING_AWS-GOV-MASTER_SECRET_KEY"` |  |
@@ -69,7 +72,6 @@ A Helm chart for Kubernetes
 | redis.redisUrl | string | `"redis://localhost:6379"` |  |
 | redis.useSentinel | string | `"true"` |  |
 | replicaCount | int | `3` |  |
-| resources.limits.cpu | int | `2` |  |
 | resources.limits.memory | string | `"4Gi"` |  |
 | resources.requests.cpu | int | `2` |  |
 | resources.requests.memory | string | `"4Gi"` |  |

--- a/src/lightwingFaktoryWorker/templates/deployment.yaml
+++ b/src/lightwingFaktoryWorker/templates/deployment.yaml
@@ -136,10 +136,19 @@ spec:
                   key: {{ .Values.lwdWorkerSecrets.faktoryPassword }}
             - name: FAKTORY_URL
               value: tcp://:$(FAKTORY_PASSWORD)@lwd-faktory.{{ .Release.Namespace }}.svc.cluster.local:7419
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+        {{- if .Values.extraVolumeMounts }}
+        {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
           - name: secret-mount
             mountPath: /opt/harness/svc
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: lwd-worker-secret-mount

--- a/src/lightwingFaktoryWorker/values.yaml
+++ b/src/lightwingFaktoryWorker/values.yaml
@@ -123,3 +123,24 @@ resources:
   requests:
     cpu: 2
     memory: "4Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/nextgen-ce/README.md
+++ b/src/nextgen-ce/README.md
@@ -38,6 +38,8 @@ A Helm chart for Kubernetes
 | cloudProviderConfig.AWS_GOV_CLOUD_TEMPLATE_LINK | string | `"https://continuous-efficiency.s3.us-east-2.amazonaws.com/setup/v1/ng/HarnessAWSTemplate.yaml"` |  |
 | cloudProviderConfig.AZURE_APP_CLIENT_ID | string | `"0211763d-24fb-4d63-865d-92f86f77e908"` |  |
 | cloudProviderConfig.GCP_SERVICE_ACCOUNT_EMAIL | string | `"placeHolder"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.ccm.gcpProjectId | string | `"placeHolder"` |  |
 | global.database.mongo.extraArgs | string | `""` |  |
@@ -88,6 +90,7 @@ A Helm chart for Kubernetes
 | ingress.className | string | `"nginx"` |  |
 | java.memory | string | `"4096m"` |  |
 | java.memoryLimit | string | `"4096m"` |  |
+| lifecycleHooks | object | `{}` |  |
 | maxSurge | string | `"100%"` |  |
 | maxUnavailable | int | `0` |  |
 | mongoSecrets.password.key | string | `"mongodb-root-password"` |  |
@@ -99,7 +102,6 @@ A Helm chart for Kubernetes
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `2` |  |
-| resources.limits.cpu | int | `1` |  |
 | resources.limits.memory | string | `"4Gi"` |  |
 | resources.requests.cpu | int | `1` |  |
 | resources.requests.memory | string | `"4Gi"` |  |

--- a/src/nextgen-ce/templates/deployment.yaml
+++ b/src/nextgen-ce/templates/deployment.yaml
@@ -102,12 +102,21 @@ spec:
                   key: {{ .Values.clickhouse.password.key }}
             {{- end }}
           {{- if not .Values.workloadIdentity.enabled }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
+        {{- if .Values.extraVolumeMounts }}
+        {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- end }}
           - name: secret-mount
             mountPath: /opt/harness/svc
           {{- end }}
       {{- if not .Values.workloadIdentity.enabled }}
       volumes:
+      {{- if .Values.extraVolumes }}
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
       - name: secret-mount
         secret:
           secretName: ceng-secret-mount

--- a/src/nextgen-ce/values.yaml
+++ b/src/nextgen-ce/values.yaml
@@ -184,3 +184,24 @@ resources:
     memory: "4Gi"
 
 additionalConfigs: {}
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/ng-ce-ui/README.md
+++ b/src/ng-ce-ui/README.md
@@ -20,6 +20,8 @@ A Helm chart for Kubernetes
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPU | string | `""` |  |
 | autoscaling.targetMemory | string | `""` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.imagePullSecrets | list | `[]` |  |
 | global.ingress.className | string | `"harness"` |  |
@@ -39,6 +41,7 @@ A Helm chart for Kubernetes
 | image.repository | string | `"harness/ng-ce-ui"` |  |
 | image.tag | string | `"0.34.3"` |  |
 | ingress.className | string | `"nginx"` |  |
+| lifecycleHooks | object | `{}` |  |
 | maxSurge | string | `"100%"` |  |
 | maxUnavailable | int | `0` |  |
 | nameOverride | string | `""` |  |
@@ -46,7 +49,6 @@ A Helm chart for Kubernetes
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `2` |  |
-| resources.limits.cpu | int | `1` |  |
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | int | `1` |  |
 | resources.requests.memory | string | `"512Mi"` |  |

--- a/src/ng-ce-ui/templates/deployment.yaml
+++ b/src/ng-ce-ui/templates/deployment.yaml
@@ -55,6 +55,18 @@ spec:
           - name: ng-ce-ui-port
             containerPort: 8080
             protocol: "TCP"
+<<<<<<< HEAD
+=======
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -76,4 +88,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/ng-ce-ui/values.yaml
+++ b/src/ng-ce-ui/values.yaml
@@ -79,3 +79,24 @@ resources:
   requests:
     cpu: 1
     memory: "512Mi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:

--- a/src/telescopes/README.md
+++ b/src/telescopes/README.md
@@ -20,6 +20,8 @@ A Helm chart for Kubernetes
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPU | string | `""` |  |
 | autoscaling.targetMemory | string | `""` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.imagePullSecrets | list | `[]` |  |
 | global.ingress.className | string | `"harness"` |  |
@@ -41,12 +43,12 @@ A Helm chart for Kubernetes
 | ingress.className | string | `"nginx"` |  |
 | java.memory | string | `"4096m"` |  |
 | java.memoryLimit | string | `"4096m"` |  |
+| lifecycleHooks | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"512m"` |  |
 | resources.limits.memory | string | `"1Gi"` |  |
 | resources.requests.cpu | string | `"512m"` |  |
 | resources.requests.memory | string | `"1Gi"` |  |

--- a/src/telescopes/templates/deployment.yaml
+++ b/src/telescopes/templates/deployment.yaml
@@ -44,6 +44,18 @@ spec:
           - |
             /bin/telescopes \
             --cloudinfo-address="http://cloud-info.{{ .Release.Namespace }}.svc.cluster.local:8082/api/v1"
+<<<<<<< HEAD
+=======
+        {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+        {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "harnesscommon.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+>>>>>>> 57f816f (SMP-1468 Add lifecyclehooks, volume, volumemounts (#78))
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -65,4 +77,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}

--- a/src/telescopes/values.yaml
+++ b/src/telescopes/values.yaml
@@ -88,3 +88,24 @@ resources:
   requests:
     cpu: "512m"
     memory: "1Gi"
+
+# extraVolumes:
+#   - name: volume-test
+#     configMap:
+#       name: test-config
+#       # readOnly: true
+extraVolumes: []
+
+# extraVolumeMounts:
+#   - name: volume-test
+#     mountPath: /opt/harness/config
+extraVolumeMounts: []
+
+lifecycleHooks: {}
+# lifecycleHooks:
+#   postStart:
+#     exec:
+#       command:
+#   preStop:
+#     exec:
+#       command:


### PR DESCRIPTION
Currently override file does not allow for following :

lifecycle.postStart, lifecycle.preStop, volume and volume mount - need for JFR integration

This would be helpful as part of performance testing to add additional volumes and volumeMounts for certain files like jfr recording etc, preStop, postStart lifecycle hooks.

This functionality will help in future if we need to mount certificates on the container if required(mongo/postgres certificates) or analysing the cause of crashes.

These are created with checking best practices like bitnami charts in mind. It is currently harmless in nature, and can be invoked by setting the configurations in overrides/values.yaml